### PR TITLE
Fixed top bar styling, made responsive.

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,18 +40,25 @@
   width: max(10vw, 15vh);
   align-self: center;
   position: absolute;
-  right: 2%; 
+  right: 2%;
 }
 
 .TopRightButton {
-  color: #A46DDB !important;
-  border-color: #A46DDB !important;
+  color: #a46ddb !important;
+  border-color: #a46ddb !important;
 }
 
+.TopRightButton:active,
 .TopRightButton:hover {
-  background-color: #A46DDB !important;
+  background-color: #a46ddb !important;
   color: #f8f1ff !important;
 }
+
+.TopRightButton:focus { 
+  box-shadow: none !important;
+}
+
+
 
 .BodyContainer {
   display: flex;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,6 +12,7 @@
   flex-direction: row;
   padding-top: 3vh;
   padding-bottom: 10vh;
+  align-items: space-between;
 }
 
 .LogoContainer {
@@ -19,7 +20,6 @@
   flex-direction: row;
   font-size: min(15vw, 15vh);
   align-self: center;
-  padding-left: 35vw;
 }
 
 .LeftLogoText {
@@ -37,15 +37,13 @@
 }
 
 .TRButtonContainer {
-  padding-left: 25vw;
+  width: max(10vw, 15vh);
   align-self: center;
+  position: absolute;
+  right: 2%; 
 }
 
 .TopRightButton {
-  height: 5vw !important;
-  width: 10vw;
-  font-size: 30px !important;
-  font-weight: 300 !important;
   color: #A46DDB !important;
   border-color: #A46DDB !important;
 }

--- a/frontend/src/components/topbar.js
+++ b/frontend/src/components/topbar.js
@@ -1,8 +1,35 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import "../App.css";
 import { Button } from "reactstrap";
 
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height
+  };
+}
+
+function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowDimensions;
+}
+
 function TopBar() {
+  const { height, width } = useWindowDimensions();
+  console.log(height, width);
   return (
     <div className="TopBar">
       <div className="LogoContainer">
@@ -10,7 +37,12 @@ function TopBar() {
         <div className="RightLogoText">lift</div>
       </div>
       <div className="TRButtonContainer">
-        <Button outline className="TopRightButton">
+        <Button
+          outline
+          size={height*.75 < width ? "lg" : "sm"}
+          block={height*.75 < width}
+          className="TopRightButton"
+        >
           profile
         </Button>
       </div>

--- a/frontend/src/components/topbar.js
+++ b/frontend/src/components/topbar.js
@@ -36,7 +36,7 @@ function TopBar() {
         <div className="LeftLogoText">up</div>
         <div className="RightLogoText">lift</div>
       </div>
-      <div className="TRButtonContainer">
+      <div className="TRButtonContainer shadow-none">
         <Button
           outline
           size={height*.75 < width ? "lg" : "sm"}


### PR DESCRIPTION
I changed the styling for the top bar so that things aren't aligned using padding and the button acts more appropriately upon resize.

Photos:

Desktop Size: 

![image](https://user-images.githubusercontent.com/32982087/84574535-10a13280-ad75-11ea-943a-c5f0f4050fe3.png)

iPhone X Size:

![image](https://user-images.githubusercontent.com/32982087/84574565-43e3c180-ad75-11ea-8be7-0600ee0f5e9f.png)

